### PR TITLE
v0.3 update to Issue #2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Pipelines"
 uuid = "ef544631-5c6f-4e9b-994c-12e7a4cd724c"
 authors = ["Jiacheng Chuan <jiacheng_chuan@outlook.com>"]
-version = "0.2.2"
+version = "0.3.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -48,37 +48,44 @@ Let's set up a simple `CmdProgram` to print values using `echo`:
 using Pipelines
 
 echo = CmdProgram(
-    inputs = ["INPUT1", "INPUT2"],
-    cmd = `echo INPUT1 INPUT2`   
+    inputs = [
+        "REQUIRED",               # no default value; any data type.
+        "TYPED" => String,        # no default value; String type only.
+        "OPTIONAL" => 4,          # default value is 5; any data type.
+        "FULL" => String => "abc" # default value is abc; String type only.
+    ],
+    cmd = `echo REQUIRED TYPED OPTIONAL FULL`   
 )
 ```
 
-Running the program is just like running other `Cmd`,  but here we need to specify inputs by using `Dict{String}`.
+Running the program is just like running other `Cmd`,  but here we need to specify inputs by using `Dict{String => value}` (`Vector{String => value}` is also supported.)
 
 ```julia
 inputs = Dict(
-    "INPUT1" => "Hello,",
-    "INPUT2" => `Pipeline.jl`
+    "REQUIRED" => "Pipelines.jl",
+    "TYPED" => "is",
+    "FULL" => "everyone!"
 )
 run(echo, inputs)
 ```
 
 !!! note "Program will not run twice by default!"
     If you run a program with the same inputs again, the program will just return the same result, display a warning message without running the command twice.
+
     ```julia
     run(echo, inputs)
     ```
 
     This is because the program will generate a file (run id file) in the current directory indicating the program has been run. Several methods can be used to re-run a program:
-
+    
     ```julia
     # Method 1: stop checking finished program
     run(echo, inputs; skip_when_done = false)
-
+    
     # Method 2: delete the run_id_file before running again:
     cmd, run_id_file = run(echo, inputs; dry_run = true) # Dry-run returns the command and run id file without running it.
     rm(run_id_file)  # remove the run_id_file
-
+    
     # Method 3: Do not generate run_id_file when first running.
     run(echo, inputs; touch_run_id_file=false)
     ```
@@ -92,7 +99,7 @@ The following program prints values simultaneously, sort them, and save to a fil
 ```julia
 prog = CmdProgram(
     inputs = ["INPUT1", "INPUT2", "INPUT3"],
-    outputs = ["OUTPUT_FILE"],
+    outputs = "OUTPUT_FILE",
     cmd = pipeline(`echo INPUT1 INPUT2` & `echo INPUT3`, `sort`, "OUTPUT_FILE")
 )
 
@@ -101,23 +108,58 @@ inputs = Dict(
     "INPUT2" => `Pipeline.jl`,
     "INPUT3" => 39871
 )
-outputs = Dict("OUTPUT_FILE" => "out.txt")
+outputs = "OUTPUT_FILE" => "out.txt" # save output to file
 
 run(prog, inputs, outputs) # will return (success::Bool, outputs)
+
+run(`cat out.txt`) # print the content of out.txt
+# 39871
+# Hello, Pipeline.jl
 ```
 
-It is inconvenient to specify outputs every time, so we provide an argument (`infer_outputs::Function`) in `CmdProgram` to generate default outputs from inputs.
+### Default values
+
+Default values and data types can be set for keywords of `inputs` and `outputs` in this way:
 
 ```julia
+echo = CmdProgram(
+    inputs = [
+        "REQUIRED",                     # no default value; any data type.
+        "TYPED" => String,              # no default value; String type only.
+        "OPTIONAL" => 4,                # default value is 5; any data type.
+        "FULL1" => String => "abc"      # default value is abc; String type only.
+        "FULL2" => "abc" => String      # default value is abc; String type only.
+        "INTERPOLATED" => "<FULL1>.xyz" # default value is value of FULL1 * ".xyz".
+    ],
+    cmd = `echo REQUIRED TYPED OPTIONAL FULL`   
+)
+```
+
+#### Interpolation of default values
+
+If the default value is a `String`, it can be interpolated by using `<keyword>`, such as `"<FULL1>.xyz"` in the example.
+
+#### Generate outputs using Function
+
+> This step is prior to adding default values of outputs, and string interpolation using `<>`.
+
+We also provide a method (`infer_outputs::Function`) in `CmdProgram` to generate complex `outputs::Dict{String}` from `inputs::Dict{String}`. The type used in the function is restricted to `Dict{String}`
+
+```julia
+using Dates
+
 prog = CmdProgram(
-    inputs = ["INPUT1", "INPUT2", "INPUT3"],
-    outputs = ["OUTPUT_FILE"],
-    cmd = pipeline(`echo INPUT1 INPUT2` & `echo INPUT3`, `sort`, "OUTPUT_FILE"),
+    inputs = [
+        "INPUT1" => Int,
+        "INPUT2" => Int => 3
+    ],
+    outputs = "OUTPUT_FILE",
+    cmd = pipeline(`echo INPUT1 INPUT2`, `sort`, "OUTPUT_FILE"),
     infer_outputs = inputs -> Dict(
-    	"OUTPUT_FILE" => inputs["INPUT1"] * ".txt"
+    	"OUTPUT_FILE" => string(now(), "__", inputs["INPUT1"], ".txt")
     )
 )
-success, outputs = run(prog, inputs)
+success, outputs = run(prog, "INPUT1" => 5)
 ```
 
 We can also generate default outputs without running the program:

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -77,15 +77,15 @@ run(echo, inputs)
     ```
 
     This is because the program will generate a file (run id file) in the current directory indicating the program has been run. Several methods can be used to re-run a program:
-    
+
     ```julia
     # Method 1: stop checking finished program
     run(echo, inputs; skip_when_done = false)
-    
+
     # Method 2: delete the run_id_file before running again:
     cmd, run_id_file = run(echo, inputs; dry_run = true) # Dry-run returns the command and run id file without running it.
     rm(run_id_file)  # remove the run_id_file
-    
+
     # Method 3: Do not generate run_id_file when first running.
     run(echo, inputs; touch_run_id_file=false)
     ```
@@ -186,63 +186,63 @@ Pipelines.jl is fully compatible with [JobSchedulers.jl](https://github.com/cihg
 
 v0.3.0
 
-- Building Program: Support type assertion and default arguments of `inputs` and `outputs`, such as `arg => 5`, `arg => Int`, `arg => 5 => Int`, `arg => Int => 5`.
+- Building Program: Support type assertion and default arguments of `inputs` and `outputs`, such as `"arg" => 5`, `"arg" => Int`, `"arg" => 5 => Int`, `"arg" => Int => 5`.
 
 - `Program` and `run(::Program)` no longer require `inputs` and `outputs` to be `Vector` or `Dict`. They can be both `Vector` or `Dict`, or even an element of `Vector` or `Dict`, as long as they can be converted. Eg:
 
-    ```julia
-    p = CmdProgram(
-        cmd_dependencies = [julia],
-        id_file = "id_file",
-        inputs = [
-            "input",
-            "input2" => Int,
-            "optional_arg" => 5,
-            "optional_arg2" => 0.5 => Number
-        ],
-        outputs = "output" => "<input>.output"
-        ,
-        cmd = `echo input input2 optional_arg optional_arg2 output`
-    )
+  ```julia
+  p = CmdProgram(
+      cmd_dependencies = [julia],
+      id_file = "id_file",
+      inputs = [
+          "input",
+          "input2" => Int,
+          "optional_arg" => 5,
+          "optional_arg2" => 0.5 => Number
+      ],
+      outputs = "output" => "<input>.output"
+      ,
+      cmd = `echo input input2 optional_arg optional_arg2 output`
+  )
 
-    inputs = Dict(
-        "input" => `in1`,
-        "input2" => 2
-    )
+  inputs = Dict(
+      "input" => `in1`,
+      "input2" => 2
+  )
 
-    outputs = [
-        "output" => "out"
-    ]
+  outputs = [
+      "output" => "out"
+  ]
 
-    run(p, inputs, outputs,
-        skip_when_done = false,
-        verbose = true,
-        touch_run_id_file = false
-    )
-    ```
+  run(p, inputs, outputs,
+      skip_when_done = false,
+      verbose = true,
+      touch_run_id_file = false
+  )
+  ```
 
 - Pretty print of `Program`. Eg:
 
-    ```julia
-    julia> p
-    CmdProgram:
-      name             → Command Program
-      id_file          → id_file
-      info_before      → auto
-      info_after       → auto
-      cmd_dependencies → CmdDependency[`/usr/software/julia-1.4.2/bin/julia -Cnative -J/usr/software/julia-1.4.2/lib/julia/sys.so -O3 -g1`]
-      inputs           → "input"         :: Any    (required)
-                         "input2"        :: Int64  (required)
-                         "optional_arg"  :: Any    (default: 5)
-                         "optional_arg2" :: Number (default: 0.5)
-      validate_inputs  → do_nothing
-      prerequisites    → do_nothing
-      cmd              → `echo input input2 optional_arg optional_arg2 output`
-      infer_outputs    → do_nothing
-      outputs          → "output" :: Any (default: <input>.output)
-      validate_outputs → do_nothing
-      wrap_up          → do_nothing
-    ```
+  ```julia
+  julia> p
+  CmdProgram:
+    name             → Command Program
+    id_file          → id_file
+    info_before      → auto
+    info_after       → auto
+    cmd_dependencies → CmdDependency[`/usr/software/julia-1.4.2/bin/julia -Cnative -J/usr/software/julia-1.4.2/lib/julia/sys.so -O3 -g1`]
+    inputs           → "input"         :: Any    (required)
+                       "input2"        :: Int64  (required)
+                       "optional_arg"  :: Any    (default: 5)
+                       "optional_arg2" :: Number (default: 0.5)
+    validate_inputs  → do_nothing
+    prerequisites    → do_nothing
+    cmd              → `echo input input2 optional_arg optional_arg2 output`
+    infer_outputs    → do_nothing
+    outputs          → "output" :: Any (default: <input>.output)
+    validate_outputs → do_nothing
+    wrap_up          → do_nothing
+  ```
 
 v0.2.2
 

--- a/src/CmdDependency.jl
+++ b/src/CmdDependency.jl
@@ -143,21 +143,6 @@ function check_dependency(p::CmdDependency)
 	return false
 end
 
-function Base.display(p::CmdDependency)
-	print("CmdDependency\n  exec            :")
-	display(p.exec)
-	print("  test_args       :")
-	display(p.test_args)
-	println("  validate_success: $(p.validate_success)\n  validate_stdout : $(p.validate_stdout)\n  validate_stderr : $(p.validate_stderr)\n  exit_when_fail  : $(p.exit_when_fail)")
-end
-
-function Base.print(io::IO, p::CmdDependency)
-	print(io, p.exec)
-end
-
-function Base.show(io::IO, p::CmdDependency)
-	show(io, p.exec)
-end
 
 # Interpolation in Cmd
 # It allows CmdDependency to be interpolated in `$p`.

--- a/src/CmdProgram.jl
+++ b/src/CmdProgram.jl
@@ -19,26 +19,6 @@ mutable struct CmdProgram <: Program
 end
 
 """
-# Struct
-
-	mutable struct CmdProgram
-		name::String
-		id_file::String
-		info_before::String
-		info_after::String
-		cmd_dependencies::Vector{CmdDependency}
-		inputs::Vector{String}
-		validate_inputs::Function
-		prerequisites::Function
-		cmd::Base.AbstractCmd
-		infer_outputs::Function
-		outputs::Vector{String}
-		validate_outputs::Function
-		wrap_up::Function
-	end
-
-# Methods
-
 	CmdProgram(;
 		name::String               = "Unnamed Command Program",
 		id_file::String            = "",
@@ -137,12 +117,14 @@ function CmdProgram(;
 		info_after,
 		cmd_dependencies,
 		inputs,
+		input_types,
 		default_inputs,
 		validate_inputs,
 		prerequisites,
 		cmd,
 		infer_outputs,
 		outputs,
+		output_types
 		default_outputs,
 		validate_outputs,
 		wrap_up

--- a/src/CmdProgram.jl
+++ b/src/CmdProgram.jl
@@ -19,6 +19,8 @@ mutable struct CmdProgram <: Program
 end
 
 """
+	CmdProgram <: Program
+
 	CmdProgram(;
 		name::String               = "Unnamed Command Program",
 		id_file::String            = "",
@@ -49,18 +51,17 @@ Command program template. To run a `CmdProgram`, use `run(::CmdProgram; kwargs..
 
 - `cmd_dependencies::Vector{CmdDependency}`: Any command dependencies used in the program.
 
-- `inputs` and `outputs`: `Vector{keyword::String [=> default_value] [=> data_type]}`.  
+- `inputs` and `outputs`: `Vector`, and the elements in the following format: (1) `keyword::String` (2) `keyword::String => data_type` (3) `keyword::String => default_value` (4) `keyword::String => default_value => data_type`.
 
-  `keyword` is an argument name. 
-  
-  `default_value` is optional. If set, users may not provide this argument when running. Elsewise, users have to provide it. Caution: `nothing` is preserved and means default value not set. If `String`, it can contain other keyword, but need to quote using '<>', such as `"<arg>.txt"`
-  
+  `keyword` is an argument name.
+
+  `default_value` is optional. If set, users may not provide this argument when running. Elsewise, users have to provide it. Caution: `nothing` is preserved and means default value not set. If `String`, it can contain other keywords, but need to quote using '<>', such as `"<arg>.txt"`
+
   `data_type` is optional. If set, the value provided have to be this data type, or an error will throw.
-  
+
   *HOW DOES THIS WORK?*
 
   > `CmdProgram` stores a command template. In the template, replaceable portions are occupied by *keywords*, and all keywords are set in `inputs` and `outputs`.
-
   > `keyword`s will be replaced before running the program. Users need to provide a dictionary of `keyword::String => value` in `run(::Program, inputs::Dict{String}, outputs::Dict{String})`.
 
 - `validate_inputs::Function`: A function to validate inputs. It takes *one* argument `Dict{String, ValidInputTypes}` whose keys are the same as `inputs`. If validation fail, throw error or return false.
@@ -80,7 +81,7 @@ Command program template. To run a `CmdProgram`, use `run(::CmdProgram; kwargs..
 	p = CmdProgram(
 		id_file = "id_file",
 		inputs = [
-			"input", 
+			"input",
 			"input2" => Int,
 			"optional_arg" => 5,
 			"optional_arg2" => 0.5 => Number
@@ -146,8 +147,8 @@ end
 """
 	run(
 		p::CmdProgram;
-		inputs::Dict{String}=Dict{String, Cmd}(),
-		outputs::Dict{String}=Dict{String, Cmd}(),
+		inputs::Dict{String}=Dict{String}(),
+		outputs::Dict{String}=Dict{String}(),
 		skip_when_done::Bool=true,
 		check_dependencies::Bool=true,
 		stdout=nothing,
@@ -237,8 +238,8 @@ Return `(success::Bool, outputs::Dict{String})`
 """
 function Base.run(
 	p::CmdProgram;
-	inputs::Dict{String}=Dict{String, Cmd}(),
-	outputs::Dict{String}=Dict{String, Cmd}(),
+	inputs::Dict{String}=Dict{String, Any}(),
+	outputs::Dict{String}=Dict{String, Any}(),
 	skip_when_done::Bool=true,
 	check_dependencies::Bool=true,
 	stdout=nothing,

--- a/src/CmdProgram.jl
+++ b/src/CmdProgram.jl
@@ -51,9 +51,9 @@ Command program template. To run a `CmdProgram`, use `run(::CmdProgram; kwargs..
 
 - `cmd_dependencies::Vector{CmdDependency}`: Any command dependencies used in the program.
 
-- `inputs` and `outputs`: `Vector`, and the elements in the following format: (1) `keyword::String` (2) `keyword::String => data_type` (3) `keyword::String => default_value` (4) `keyword::String => default_value => data_type`.
+- `inputs` and `outputs`: Elements (or vectors containing elements) in the following format: (1) `keyword` (2) `keyword => data_type` (3) `keyword => default_value` (4) `keyword => default_value => data_type`.
 
-  `keyword` is an argument name.
+  `keyword` is an argument name, can be `String` or `Symbol`.
 
   `default_value` is optional. If set, users may not provide this argument when running. Elsewise, users have to provide it. Caution: `nothing` is preserved and means default value not set. If `String`, it can contain other keywords, but need to quote using '<>', such as `"<arg>.txt"`
 
@@ -86,9 +86,9 @@ Command program template. To run a `CmdProgram`, use `run(::CmdProgram; kwargs..
 			"optional_arg" => 5,
 			"optional_arg2" => 0.5 => Number
 		],
-		outputs = [
+		outputs =
 			"output" => "<input>.output"
-		],
+		,
 		cmd = `echo input input2 optional_arg optional_arg2 output`
 	)
 
@@ -147,8 +147,8 @@ end
 """
 	run(
 		p::CmdProgram;
-		inputs::Dict{String}=Dict{String}(),
-		outputs::Dict{String}=Dict{String}(),
+		inputs=Dict{String}(),
+		outputs=Dict{String}(),
 		skip_when_done::Bool=true,
 		check_dependencies::Bool=true,
 		stdout=nothing,
@@ -159,18 +159,10 @@ end
 		dry_run::Bool=false
 	) -> (success::Bool, outputs::Dict{String})
 
-	run(
-		p::CmdProgram,
-		inputs::Dict{String},
-		outputs::Dict{String};
-		kwargs...
-	)
+	run(p::CmdProgram, inputs, outputs; kwargs...)
 
-	run(
-		p::CmdProgram,
-		inputs::Dict{String},
-		kwargs...
-	)  # only usable when `p.infer_outputs` is defined.
+	run(p::CmdProgram, inputs; kwargs...)
+	)  # only usable when `p.infer_outputs` is defined, or default outputs are set in `p`.
 
 Run Command Program (CmdProgram) using specified `inputs` and `outputs`.
 
@@ -179,6 +171,8 @@ Return `(success::Bool, outputs::Dict{String})`
 - `p::CmdProgram`: the command program template.
 
 - `inputs::Dict{String}` and `outputs::Dict{String}`: `p::CmdProgram` stores a command template. In the template, replaceable portions are occupied by *keywords*, and all keywords can be found at `p.inputs` and `p.outputs` string vectors. Here, `inputs` and `outputs` are `Dict(keyword::String => replacement)`. The replacements do not have a length limit, unless a *keyword* refers to a filename (length == 1).
+
+  > If data types of `inputs` and `outputs` are not `Dict{String}`, they will be converted as far as possible. If the conversion fails, program will throw an error.  
 
 - `skip_when_done::Bool = true`: Skip running the program and return `true` if it has been done before (the `run_id_file` exists and `p.validate_outputs(outputs)` passes.)
 
@@ -238,8 +232,8 @@ Return `(success::Bool, outputs::Dict{String})`
 """
 function Base.run(
 	p::CmdProgram;
-	inputs::Dict{String}=Dict{String, Any}(),
-	outputs::Dict{String}=Dict{String, Any}(),
+	inputs=Dict{String, Any}(),
+	outputs=Dict{String, Any}(),
 	skip_when_done::Bool=true,
 	check_dependencies::Bool=true,
 	stdout=nothing,

--- a/src/CmdProgram.jl
+++ b/src/CmdProgram.jl
@@ -22,7 +22,7 @@ end
 	CmdProgram <: Program
 
 	CmdProgram(;
-		name::String               = "Unnamed Command Program",
+		name::String               = "Command Program",
 		id_file::String            = "",
 		info_before::String        = "auto",
 		info_after::String         = "auto",
@@ -172,7 +172,7 @@ Return `(success::Bool, outputs::Dict{String})`
 
 - `inputs::Dict{String}` and `outputs::Dict{String}`: `p::CmdProgram` stores a command template. In the template, replaceable portions are occupied by *keywords*, and all keywords can be found at `p.inputs` and `p.outputs` string vectors. Here, `inputs` and `outputs` are `Dict(keyword::String => replacement)`. The replacements do not have a length limit, unless a *keyword* refers to a filename (length == 1).
 
-  > If data types of `inputs` and `outputs` are not `Dict{String}`, they will be converted as far as possible. If the conversion fails, program will throw an error.  
+  > If data types of `inputs` and `outputs` are not `Dict{String}`, they will be converted as far as possible. If the conversion fails, program will throw an error.
 
 - `skip_when_done::Bool = true`: Skip running the program and return `true` if it has been done before (the `run_id_file` exists and `p.validate_outputs(outputs)` passes.)
 

--- a/src/CmdProgram.jl
+++ b/src/CmdProgram.jl
@@ -5,11 +5,15 @@ mutable struct CmdProgram <: Program
 	info_after::String
     cmd_dependencies::Vector{CmdDependency}
 	inputs::Vector{String}
+	input_types::Vector{DataType}
+	default_inputs::Vector{String}
 	validate_inputs::Function
 	prerequisites::Function
     cmd::Base.AbstractCmd
 	infer_outputs::Function
 	outputs::Vector{String}
+	output_types::Vector{DataType}
+	default_outputs::Vector{String}
 	validate_outputs::Function
 	wrap_up::Function
 end
@@ -113,14 +117,19 @@ function CmdProgram(;
 	info_after::String         = "auto",
 	cmd_dependencies::Vector{CmdDependency} = Vector{CmdDependency}(),
 	inputs::Vector{String}     = Vector{String}(),
+    # default_inputs::Vector{String} = Vector{String}(),
 	validate_inputs::Function  = do_nothing,  # positional arguments: inputs::Dict{String}
 	prerequisites::Function    = do_nothing,  # positional arguments: inputs, outputs::Dict{String}
 	cmd::Base.AbstractCmd      = ``,
 	infer_outputs::Function    = do_nothing,  # positional arguments: inputs::Dict{String}
 	outputs::Vector{String}    = Vector{String}(),
+	# default_outputs::Vector{String} = Vector{String}(),
 	validate_outputs::Function = do_nothing,  # positional arguments: outputs::Dict{String}
 	wrap_up::Function          = do_nothing  # positional arguments: inputs, outputs::Dict{String}
 )
+	inputs, default_inputs = parse_default(inputs)
+	outputs, default_outputs = parse_default(outputs)
+
 	CmdProgram(
 		name,
 		id_file,
@@ -128,11 +137,13 @@ function CmdProgram(;
 		info_after,
 		cmd_dependencies,
 		inputs,
+		default_inputs,
 		validate_inputs,
 		prerequisites,
 		cmd,
 		infer_outputs,
 		outputs,
+		default_outputs,
 		validate_outputs,
 		wrap_up
 	)

--- a/src/JuliaProgram.jl
+++ b/src/JuliaProgram.jl
@@ -51,9 +51,9 @@ Julia program template. To run a `JuliaProgram`, use `run(::JuliaProgram; kwargs
 
 - `cmd_dependencies::Vector{CmdDependency}`: Any command dependencies used in the program.
 
-- `inputs` and `outputs`: `Vector`, and the elements in the following format: (1) `keyword::String` (2) `keyword::String => data_type` (3) `keyword::String => default_value` (4) `keyword::String => default_value => data_type`.
+- `inputs` and `outputs`: Elements (or vectors containing elements) in the following format: (1) `keyword` (2) `keyword => data_type` (3) `keyword => default_value` (4) `keyword => default_value => data_type`.
 
-  `keyword` is an argument name.
+  `keyword` is an argument name, can be `String` or `Symbol`.
 
   `default_value` is optional. If set, users may not provide this argument when running. Elsewise, users have to provide it. Caution: `nothing` is preserved and means default value not set. If `String`, it can contain other keywords, but need to quote using '<>', such as `"<arg>.txt"`
 
@@ -86,9 +86,9 @@ Julia program template. To run a `JuliaProgram`, use `run(::JuliaProgram; kwargs
 			"a",
 			"b" => Int
 		],
-		outputs = [
+		outputs =
 			"c" => "<a>.<b>"
-		],
+		,
 		main = (inputs, outputs) -> begin
 			a = inputs["a"]
 			b = inputs["b"]
@@ -155,8 +155,8 @@ end
 """
 	run(
 		p::JuliaProgram;
-		inputs::Dict{String}=Dict{String}(),
-		outputs::Dict{String}=Dict{String}(),
+		inputs=Dict{String}(),
+		outputs=Dict{String}(),
 		skip_when_done::Bool=true,
 		check_dependencies::Bool=true,
 		stdout=nothing,
@@ -167,18 +167,10 @@ end
 		dry_run::Bool=false
 	) -> (success::Bool, outputs::Dict{String})
 
-	run(
-		p::JuliaProgram,
-		inputs::Dict{String},
-		outputs::Dict{String};
-		kwargs...
-	)
+	run(p::JuliaProgram, inputs, outputs; kwargs...)
 
-	run(
-		p::JuliaProgram,
-		inputs::Dict{String},
-		kwargs...
-	)  # only usable when `p.infer_outputs` is defined.
+	run(p::JuliaProgram, inputs; kwargs...)
+	)  # only usable when `p.infer_outputs` is defined, or default outputs are set in `p`.
 
 Run Julia Program (JuliaProgram) using specified `inputs` and `outputs`.
 
@@ -188,7 +180,8 @@ Return `(success::Bool, outputs::Dict{String})`
 
 - `inputs::Dict{String}` and `outputs::Dict{String}`: `JuliaProgram` stores a Julia function, with two arguments `inputs::Dict{String}, outputs::Dict{String}`. The keys of the two arguments should be the same as `p.inputs::Vector{String}` and `p.outputs::Vector{String}`.
 
-  > Caution: the returned value of `p.main` will be assigned to new `outputs`. Please ensure the returned value of `p.main` is `Dict{String}` with proper keys.
+  > If data types of `inputs` and `outputs` are not `Dict{String}`, they will be converted as far as possible. If the conversion fails, program will throw an error.  
+  > *Caution:* the returned value of `p.main` will be assigned to new `outputs`. Please ensure the returned value of `p.main` is `Dict{String}` with proper keys.
 
 - `skip_when_done::Bool = true`: Skip running the program and return `true` if it has been done before (the `run_id_file` exists and `p.validate_outputs(outputs)` passes.)
 
@@ -254,8 +247,8 @@ Return `(success::Bool, outputs::Dict{String})`
 """
 function Base.run(
 	p::JuliaProgram;
-	inputs::Dict{String}=Dict{String, Any}(),
-	outputs::Dict{String}=Dict{String, Any}(),
+	inputs=Dict{String, Any}(),
+	outputs=Dict{String, Any}(),
 	skip_when_done::Bool=true,
 	check_dependencies::Bool=true,
 	stdout=nothing,

--- a/src/JuliaProgram.jl
+++ b/src/JuliaProgram.jl
@@ -5,35 +5,21 @@ mutable struct JuliaProgram <: Program
 	info_after::String
     cmd_dependencies::Vector{CmdDependency}
 	inputs::Vector{String}
+	input_types::Vector{DataType}
+	default_inputs::Vector
 	validate_inputs::Function
 	prerequisites::Function
     main::Function
 	infer_outputs::Function
 	outputs::Vector{String}
+	output_types::Vector{DataType}
+	default_outputs::Vector
 	validate_outputs::Function
 	wrap_up::Function
 end
 
 """
-# Struct
-
-	mutable struct JuliaProgram <: Program
-		name::String
-		id_file::String
-		info_before::String
-		info_after::String
-		cmd_dependencies::Vector{CmdDependency}
-		inputs::Vector{String}
-		validate_inputs::Function
-		prerequisites::Function
-		main::Function
-		infer_outputs::Function
-		outputs::Vector{String}
-		validate_outputs::Function
-		wrap_up::Function
-	end
-
-# Methods
+	JuliaProgram <: Program
 
 	JuliaProgram(;
 		name::String               = "Unnamed Command Program",
@@ -41,12 +27,12 @@ end
 		info_before::String        = "auto",
 		info_after::String         = "auto",
 		cmd_dependencies::Vector{CmdDependency} = Vector{CmdDependency}(),
-		inputs::Vector{String}     = Vector{String}(),
+		inputs                     = Vector{String}(),
 		validate_inputs::Function  = do_nothing,  # positional arguments: inputs::Dict{String}
 		prerequisites::Function    = do_nothing,  # positional arguments: inputs, outputs::Dict{String}
 		main::Function             = do_nothing,  # positional arguments: inputs, outputs::Dict{String}
 		infer_outputs::Function    = do_nothing,  # positional arguments: inputs::Dict{String}
-		outputs::Vector{String}    = Vector{String}(),
+		outputs                    = Vector{String}(),
 		validate_outputs::Function = do_nothing  # positional arguments: outputs::Dict{String},
 		wrap_up::Function          = do_nothing  # positional arguments: inputs, outputs::Dict{String}
 	) -> JuliaProgram
@@ -65,10 +51,17 @@ Julia program template. To run a `JuliaProgram`, use `run(::JuliaProgram; kwargs
 
 - `cmd_dependencies::Vector{CmdDependency}`: Any command dependencies used in the program.
 
-- `inputs` and `outputs`: *keys* (`Vector{String}`) of dicts which are required by `run(::JuliaProgram, inputs::Dict{String}, outputs::Dict{String})`. See details below.
+- `inputs` and `outputs`: `Vector`, and the elements in the following format: (1) `keyword::String` (2) `keyword::String => data_type` (3) `keyword::String => default_value` (4) `keyword::String => default_value => data_type`.
+
+  `keyword` is an argument name.
+
+  `default_value` is optional. If set, users may not provide this argument when running. Elsewise, users have to provide it. Caution: `nothing` is preserved and means default value not set. If `String`, it can contain other keywords, but need to quote using '<>', such as `"<arg>.txt"`
+
+  `data_type` is optional. If set, the value provided have to be this data type, or an error will throw.
+
+  *HOW DOES THIS WORK?*
 
   > `JuliaProgram` stores a Julia function, with two arguments `inputs::Dict{String}, outputs::Dict{String}`. The keys of the two arguments should be set in `inputs::Vector{String}` and `outputs::Vector{String}`.
-
   > Caution: the returned value of `p.main` will be assigned to new `outputs`. Please ensure the returned value is `Dict{String}` with proper keys.
 
 - `validate_inputs::Function`: A function to validate inputs. It takes *one* argument `Dict{String}` whose keys are the same as `inputs`. If validation fail, throw error or return false.
@@ -89,8 +82,13 @@ Julia program template. To run a `JuliaProgram`, use `run(::JuliaProgram; kwargs
 
 	p = JuliaProgram(
 		id_file = "id_file",
-		inputs = ["a", "b"],
-		outputs = ["c"],
+		inputs = [
+			"a",
+			"b" => Int
+		],
+		outputs = [
+			"c" => "<a>.<b>"
+		],
 		main = (inputs, outputs) -> begin
 			a = inputs["a"]
 			b = inputs["b"]
@@ -121,15 +119,18 @@ function JuliaProgram(;
 	info_before::String        = "auto",
 	info_after::String         = "auto",
 	cmd_dependencies::Vector{CmdDependency} = Vector{CmdDependency}(),
-	inputs::Vector{String}     = Vector{String}(),
+	inputs                     = Vector{String}(),
 	validate_inputs::Function  = do_nothing,  # positional arguments: inputs::Dict{String}
 	prerequisites::Function    = do_nothing,  # positional arguments: inputs, outputs::Dict{String}
 	main::Function             = do_nothing,  # positional arguments: inputs, outputs::Dict{String},
 	infer_outputs::Function    = do_nothing,  # positional arguments: inputs::Dict{String}
-	outputs::Vector{String}    = Vector{String}(),
+	outputs                    = Vector{String}(),
 	validate_outputs::Function = do_nothing,  # positional arguments: outputs::Dict{String}
 	wrap_up::Function          = do_nothing  # positional arguments: inputs, outputs::Dict{String}
 )
+	inputs, input_types, default_inputs = parse_default(inputs)
+	outputs, output_types, default_outputs = parse_default(outputs)
+
 	JuliaProgram(
 		name,
 		id_file,
@@ -137,11 +138,15 @@ function JuliaProgram(;
 		info_after,
 		cmd_dependencies,
 		inputs,
+		input_types,
+		default_inputs,
 		validate_inputs,
 		prerequisites,
 		main,
 		infer_outputs,
 		outputs,
+		output_types,
+		default_outputs,
 		validate_outputs,
 		wrap_up
 	)
@@ -150,8 +155,8 @@ end
 """
 	run(
 		p::JuliaProgram;
-		inputs::Dict{String}=Dict{String, Cmd}(),
-		outputs::Dict{String}=Dict{String, Cmd}(),
+		inputs::Dict{String}=Dict{String}(),
+		outputs::Dict{String}=Dict{String}(),
 		skip_when_done::Bool=true,
 		check_dependencies::Bool=true,
 		stdout=nothing,
@@ -249,8 +254,8 @@ Return `(success::Bool, outputs::Dict{String})`
 """
 function Base.run(
 	p::JuliaProgram;
-	inputs::Dict{String}=Dict{String, Cmd}(),
-	outputs::Dict{String}=Dict{String, Cmd}(),
+	inputs::Dict{String}=Dict{String, Any}(),
+	outputs::Dict{String}=Dict{String, Any}(),
 	skip_when_done::Bool=true,
 	check_dependencies::Bool=true,
 	stdout=nothing,
@@ -260,8 +265,9 @@ function Base.run(
 	touch_run_id_file::Bool=true,
 	dry_run::Bool=false
 )
-	# check keyword consistency (keys in inputs and outputs compatible with the function)
-	check_keywords(p, inputs, outputs)
+	# input/output completion
+	inputs, outputs = xxputs_completion_and_check(p, inputs, outputs)
+
 	# run id based on inputs and outputs
 	run_id = generate_run_uuid(inputs, outputs)
 	run_id_file = p.id_file * "." * string(run_id)

--- a/src/Pipelines.jl
+++ b/src/Pipelines.jl
@@ -25,4 +25,6 @@ export CmdProgram
 include("JuliaProgram.jl")
 export JuliaProgram
 
+include("pretty_print.jl")
+
 end # module

--- a/src/Program.jl
+++ b/src/Program.jl
@@ -169,7 +169,7 @@ function xxputs_completion_and_check(p::Program, inputs::Dict{String}, outputs::
 		# do nothing to outputs
 	else
 		if isempty(outputs) && p.infer_outputs !== do_nothing
-			outputs = p.infer_outputs(inputs)
+			outputs = to_xxput_dict(p.infer_outputs(inputs))
 		end
 		outputs = outputs_completion(p::Program, outputs::Dict{String})
 	end

--- a/src/Program.jl
+++ b/src/Program.jl
@@ -44,20 +44,141 @@ function generate_run_uuid(inputs::Dict{String}, outputs::Dict{String})
 	uuid5(UUID4, string(all_cmd))
 end
 
+"""
+	inputs_completion(p::Program, inputs::Dict{String})
+
+complete missing keywords in `inputs` and `outputs`.
+"""
+function inputs_completion(p::Program, inputs::Dict{String})
+	for (i, keyword) in enumerate(p.inputs)
+		if haskey(inputs, keyword)
+			# check types
+			check_data_type(inputs[keyword], p.input_types[i])
+		else
+			# not provided, check default
+			default = p.default_inputs[i]
+			if isnothing(default)
+				# no default
+				throw(ErrorException("ArgumentError: Program ($(p.name)) requires $keyword, but it is not provided."))
+			else
+				inputs[keyword] = default
+			end
+		end
+	end
+	inputs
+end
+function outputs_completion(p::Program, outputs::Dict{String})
+	for (i, keyword) in enumerate(p.outputs)
+		if haskey(outputs, keyword)
+			# check types
+			check_data_type(outputs[keyword], p.output_types[i])
+		else
+			# not provided, check default
+			default = p.default_outputs[i]
+			if isnothing(default)
+				# no default
+				throw(ErrorException("ArgumentError: Program '$(p.name)' requires $keyword, but it is not provided."))
+			else
+				outputs[keyword] = default
+			end
+		end
+	end
+	outputs
+end
+
+"""
+	keyword_interpolation(inputs::Dict{String}, outputs::Dict{String})
+
+Interpolate <keyword> in `String`.
+"""
+function keyword_interpolation(inputs::Dict{String}, outputs::Dict{String})
+	allputs = Dict(union(inputs, outputs))
+	keyword_interpolation(allputs::Dict{String})
+	for key in keys(inputs)
+		inputs[key] = allputs[key]
+	end
+	for key in keys(outputs)
+		outputs[key] = allputs[key]
+	end
+	inputs, outputs
+end
+function keyword_interpolation(allputs::Dict{String})
+	for key in keys(allputs)
+		keyword_interpolation(allputs, key, 1)
+	end
+	allputs
+end
+function keyword_interpolation(allputs::Dict{String}, key::String, n_recursion::Int)
+	value = allputs[key]
+	keywords = find_keywords(value)
+	isempty(keywords) && return allputs # no need to interpolate
+	for keyword in keywords
+		keyword_value = get(allputs, keyword, nothing)
+		isnothing(keyword_value) && continue # keyword not match, ignore
+		if isempty(find_keywords(keyword_value))
+			allputs[key] = replace(allputs[key], "<$keyword>" => str(keyword_value))
+		else
+			n_recursion > 20 && throw(ErrorException("ProgramArgumentError: too many recursion occurs in keyword interpolation."))
+			keyword_interpolation(allputs::Dict{String}, keyword::String, n_recursion + 1)
+		end
+	end
+	allputs
+end
+
+function find_keywords(value::T) where T<: AbstractString
+	m = eachmatch(r"<([^<>]+)>", value)
+	String[i.captures[1] for i in m]
+end
+find_keywords(not_string) = []
+
+"""
+	xxputs_completion_and_check(p::Program, inputs::Dict{String}, outputs::Dict{String})
+
+1. Check and complete `inputs` using types and values stored in `p`.
+
+2. If `outputs` is empty, run `p.infer_outputs`.
+
+3. Check and complete `outputs` using types and values stored in `p`.
+
+4. Check keyword consistency using `p`.
+
+5. Interpolate <keyword> in String in completed `inputs` and `outputs`.
+
+6. Return inputs and outputs.
+"""
+function xxputs_completion_and_check(p::Program, inputs::Dict{String}, outputs::Dict{String})
+	inputs = inputs_completion(p::Program, inputs::Dict{String})
+
+	if isempty(p.outputs)
+		# do nothing to outputs
+	else
+		if isempty(outputs) && p.infer_outputs !== do_nothing
+			outputs = p.infer_outputs(inputs)
+		end
+		outputs = outputs_completion(p::Program, outputs::Dict{String})
+	end
+
+	# check keyword consistency (keys in inputs and outputs compatible with the function)
+	check_keywords(p, inputs, outputs)
+
+	# parse <keyword> in String
+	inputs, outputs = keyword_interpolation(inputs, outputs)
+end
 
 function Base.run(p::Program, inputs::Dict{String}, outputs::Dict{String}; kwarg...)
 	run(p; inputs=inputs, outputs=outputs, kwarg...)
 end
 
 function Base.run(p::Program, inputs::Dict{String}; kwarg...)
-	if p.infer_outputs === do_nothing
-		if isempty(p.outputs)
-			run(p; inputs=inputs, kwarg...)
-		else
-			error("Cannot run Program '$(p.name)' without specifying outputs because it requires outputs but does not have a pre-defined `p.infer_outputs` function.")
-		end
-	else
-		outputs = infer_outputs(p, inputs)
-		run(p; inputs=inputs, outputs=outputs, kwarg...)
-	end
+	run(p; inputs=inputs, kwarg...)
+	# if p.infer_outputs === do_nothing
+	# 	if isempty(p.outputs)
+	# 		run(p; inputs=inputs, kwarg...)
+	# 	else
+	# 		error("Cannot run Program '$(p.name)' without specifying outputs because it requires outputs but does not have a pre-defined `p.infer_outputs` function.")
+	# 	end
+	# else
+	# 	outputs = infer_outputs(p, inputs)
+	# 	run(p; inputs=inputs, outputs=outputs, kwarg...)
+	# end
 end

--- a/src/Program.jl
+++ b/src/Program.jl
@@ -54,7 +54,11 @@ function inputs_completion(p::Program, inputs::Dict{String})
 	for (i, keyword) in enumerate(p.inputs)
 		if haskey(inputs, keyword)
 			# check types
-			check_data_type(inputs[keyword], p.input_types[i])
+			value = convert_data_type(inputs[keyword], p.input_types[i])
+			if !(value isa value_type)
+				inputs = convert(Dict{String,Any}, inputs)
+			end  # it is ok to replace in for-loop
+			inputs[keyword] = value
 		else
 			# not provided, check default
 			default = p.default_inputs[i]
@@ -76,7 +80,11 @@ function outputs_completion(p::Program, outputs::Dict{String})
 	for (i, keyword) in enumerate(p.outputs)
 		if haskey(outputs, keyword)
 			# check types
-			check_data_type(outputs[keyword], p.output_types[i])
+			value = convert_data_type(outputs[keyword], p.output_types[i])
+			if !(value isa value_type)
+				outputs = convert(Dict{String,Any}, outputs)
+			end  # it is ok to replace in for-loop
+			outputs[keyword] = value
 		else
 			# not provided, check default
 			default = p.default_outputs[i]
@@ -173,20 +181,14 @@ function xxputs_completion_and_check(p::Program, inputs::Dict{String}, outputs::
 	inputs, outputs = keyword_interpolation(inputs, outputs)
 end
 
-function Base.run(p::Program, inputs::Dict{String}, outputs::Dict{String}; kwarg...)
+function xxputs_completion_and_check(p::Program, inputs, outputs)
+	xxputs_completion_and_check(p, to_xxput_dict(inputs), to_xxput_dict(outputs))
+end
+
+function Base.run(p::Program, inputs, outputs; kwarg...)
 	run(p; inputs=inputs, outputs=outputs, kwarg...)
 end
 
-function Base.run(p::Program, inputs::Dict{String}; kwarg...)
+function Base.run(p::Program, inputs; kwarg...)
 	run(p; inputs=inputs, kwarg...)
-	# if p.infer_outputs === do_nothing
-	# 	if isempty(p.outputs)
-	# 		run(p; inputs=inputs, kwarg...)
-	# 	else
-	# 		error("Cannot run Program '$(p.name)' without specifying outputs because it requires outputs but does not have a pre-defined `p.infer_outputs` function.")
-	# 	end
-	# else
-	# 	outputs = infer_outputs(p, inputs)
-	# 	run(p; inputs=inputs, outputs=outputs, kwarg...)
-	# end
 end

--- a/src/Program.jl
+++ b/src/Program.jl
@@ -50,6 +50,7 @@ end
 complete missing keywords in `inputs` and `outputs`.
 """
 function inputs_completion(p::Program, inputs::Dict{String})
+	value_type = fieldtypes(eltype(inputs))[2]  # value type of inputs
 	for (i, keyword) in enumerate(p.inputs)
 		if haskey(inputs, keyword)
 			# check types
@@ -59,8 +60,11 @@ function inputs_completion(p::Program, inputs::Dict{String})
 			default = p.default_inputs[i]
 			if isnothing(default)
 				# no default
-				throw(ErrorException("ArgumentError: Program ($(p.name)) requires $keyword, but it is not provided."))
+				throw(ErrorException("ArgumentError: Program '$(p.name)' requires '$keyword' in inputs, but it is not provided."))
 			else
+				if !(default isa value_type)
+					inputs = convert(Dict{String,Any}, inputs)
+				end  # it is ok to replace in for-loop
 				inputs[keyword] = default
 			end
 		end
@@ -68,6 +72,7 @@ function inputs_completion(p::Program, inputs::Dict{String})
 	inputs
 end
 function outputs_completion(p::Program, outputs::Dict{String})
+	value_type = fieldtypes(eltype(outputs))[2]  # value type of outputs
 	for (i, keyword) in enumerate(p.outputs)
 		if haskey(outputs, keyword)
 			# check types
@@ -77,8 +82,11 @@ function outputs_completion(p::Program, outputs::Dict{String})
 			default = p.default_outputs[i]
 			if isnothing(default)
 				# no default
-				throw(ErrorException("ArgumentError: Program '$(p.name)' requires $keyword, but it is not provided."))
+				throw(ErrorException("ArgumentError: Program '$(p.name)' requires $keyword in outputs, but it is not provided."))
 			else
+				if !(default isa value_type)
+					outputs = convert(Dict{String,Any}, outputs)
+				end  # it is ok to replace in for-loop
 				outputs[keyword] = default
 			end
 		end
@@ -125,7 +133,7 @@ function keyword_interpolation(allputs::Dict{String}, key::String, n_recursion::
 	allputs
 end
 
-function find_keywords(value::T) where T<: AbstractString
+function find_keywords(value::T) where T <: AbstractString
 	m = eachmatch(r"<([^<>]+)>", value)
 	String[i.captures[1] for i in m]
 end

--- a/src/pretty_print.jl
+++ b/src/pretty_print.jl
@@ -1,0 +1,73 @@
+
+
+function Base.display(p::CmdDependency)
+	print("CmdDependency\n  exec             →")
+	display(p.exec)
+	print("  test_args        →")
+	display(p.test_args)
+	println("  validate_success → $(p.validate_success)\n  validate_stdout  → $(p.validate_stdout)\n  validate_stderr  → $(p.validate_stderr)\n  exit_when_fail   → $(p.exit_when_fail)")
+end
+
+function Base.print(io::IO, p::CmdDependency)
+	print(io, p.exec)
+end
+
+function Base.show(io::IO, p::CmdDependency)
+	show(io, p.exec)
+end
+
+@eval function Base.display(p::CmdProgram)
+    fs = $(fieldnames(CmdProgram))
+    fs_string = $(map(string, fieldnames(CmdProgram)))
+    max_byte = $(maximum(length, map(string, fieldnames(CmdProgram))))
+    println("$CmdProgram:")
+    for (i,f) in enumerate(fs)
+		if f == :inputs
+			print("  ", f, " " ^ (max_byte - length(fs_string[i])), " → ")
+			display_xxputs(max_byte, p.inputs, p.input_types, p.default_inputs)
+		elseif f == :outputs
+			print("  ", f, " " ^ (max_byte - length(fs_string[i])), " → ")
+			display_xxputs(max_byte, p.outputs, p.output_types, p.default_outputs)
+		elseif f in Symbol[:input_types, :default_inputs, :output_types, :default_outputs]
+		else
+			print("  ", f, " " ^ (max_byte - length(fs_string[i])), " → ")
+	        println(getfield(p, f))
+		end
+    end
+end
+
+@eval function Base.display(p::JuliaProgram)
+    fs = $(fieldnames(JuliaProgram))
+    fs_string = $(map(string, fieldnames(JuliaProgram)))
+    max_byte = $(maximum(length, map(string, fieldnames(JuliaProgram))))
+    println("$JuliaProgram:")
+    for (i,f) in enumerate(fs)
+		if f == :inputs
+			print("  ", f, " " ^ (max_byte - length(fs_string[i])), " → ")
+			display_xxputs(max_byte, p.inputs, p.input_types, p.default_inputs)
+		elseif f == :outputs
+			print("  ", f, " " ^ (max_byte - length(fs_string[i])), " → ")
+			display_xxputs(max_byte, p.outputs, p.output_types, p.default_outputs)
+		elseif f in Symbol[:input_types, :default_inputs, :output_types, :default_outputs]
+		else
+			print("  ", f, " " ^ (max_byte - length(fs_string[i])), " → ")
+	        println(getfield(p, f))
+		end
+    end
+end
+
+function display_xxputs(max_bype::Int, xxputs::Vector{String}, xxput_types::Vector{DataType}, default_xxputs::Vector)
+	n = length(xxputs)
+	max_bype_xxputs = maximum(length, xxputs)
+	max_bype_xxput_types = maximum(length, map(string, xxput_types))
+	for i in 1:n
+		name = xxputs[i]
+		type = string(xxput_types[i])
+		default = default_xxputs[i]
+		println(i == 1 ? "" : " " ^ (max_bype + 5),
+			"\"$(name)\" ", " " ^ (max_bype_xxputs - length(name)),
+			":: $(type) ", " " ^ (max_bype_xxput_types - length(type)),
+			isnothing(default) ? "(required)" : "(default: $default)"
+		)
+	end
+end

--- a/src/pretty_print.jl
+++ b/src/pretty_print.jl
@@ -58,6 +58,10 @@ end
 
 function display_xxputs(max_bype::Int, xxputs::Vector{String}, xxput_types::Vector{DataType}, default_xxputs::Vector)
 	n = length(xxputs)
+	if n == 0
+		println("<empty>")
+		return
+	end
 	max_bype_xxputs = maximum(length, xxputs)
 	max_bype_xxput_types = maximum(length, map(string, xxput_types))
 	for i in 1:n
@@ -70,4 +74,5 @@ function display_xxputs(max_bype::Int, xxputs::Vector{String}, xxput_types::Vect
 			isnothing(default) ? "(required)" : "(default: $default)"
 		)
 	end
+	return
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -144,7 +144,7 @@ function to_xxput_dict(d::Dict)
 	res
 end
 to_xxput_dict(d::Dict{String}) = d
-to_xxput_dict(any) = throw(ErrorException("DataTypeError: cannot run Program: invalid inputs or outputs"))
+to_xxput_dict(any) = throw(ErrorException("DataTypeError: cannot run Program: cannot convert to Dict{String}: inputs, outputs, or returned value of infer_outputs(inputs)"))
 
 
 ## String/Cmd conversion

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -74,6 +74,20 @@ function parse_default_element(ele::Pair{String,T}) where T
     return ele.first, Any, ele.second
 end
 
+function parse_default_element(ele::Pair{String,Any})
+    # Any is inherited from parse_default(v::Vector{Pair{String,Any}})
+    # The following code specify the detailed type, to avoid error like:
+    # inputs = [
+	# 	"a" => 10.6,
+	# 	"b" => 5 => Int
+	# ]::Vector{Pair{String,Any}
+    parse_default_element(ele.first => ele.second)
+end
+function parse_default_element(ele::Pair)
+	check_data_type(ele.first, AbstractString)
+    parse_default_element(string(ele.first) => ele.second)
+end
+
 function parse_default_element(ele::Pair{String,Pair{T,DataType}}) where T
     check_data_type(ele.second.first, ele.second.second)
     return ele.first, ele.second.second, ele.second.first

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -60,7 +60,7 @@ p = CmdProgram(
     cmd_dependencies = [julia],
     id_file = "id_file",
     inputs = [
-        "input", 
+        "input",
         "input2" => Int,
         "optional_arg" => 5,
         "optional_arg2" => 0.5 => Number
@@ -152,16 +152,21 @@ program_bowtie2 = CmdProgram(
 
 ### julia program
 p = JuliaProgram(
-	cmd_dependencies = [julia],
 	id_file = "id_file",
-	inputs = ["a", "b"],
-	outputs = ["c"],
+	inputs = [
+		"a",
+		"b" => Int
+	],
+	outputs = [
+		"c" => "<a>.<b>"
+	],
 	main = (inputs, outputs) -> begin
 		a = inputs["a"]
 		b = inputs["b"]
 		println("inputs are ", a, " and ", b)
-		println("You can also use info in outputs:", outputs["c"])
+		println("You can also use info in outputs: ", outputs["c"])
 		println("The returned value will be assigned to a new outputs")
+
 		return Dict{String,Any}("c" => b^2)
 	end
 )
@@ -178,3 +183,32 @@ outputs = Dict(
 success, outputs = run(p, inputs, outputs;
 	touch_run_id_file = false
 ) # outputs will be refreshed
+
+success, outputs = run(p, inputs;
+	touch_run_id_file = false
+) # outputs will be refreshed
+
+### run program without inputs outputs
+p = JuliaProgram(
+	id_file = "id_file",
+	inputs = [
+		"a" => 10.6,
+		"b" =>  5 => Int
+	],
+	outputs = [
+		"c" => "<a>.<b>"
+	],
+	main = (inputs, outputs) -> begin
+		a = inputs["a"]
+		b = inputs["b"]
+		println("inputs are ", a, " and ", b)
+		println("You can also use info in outputs: ", outputs["c"])
+		println("The returned value will be assigned to a new outputs")
+
+		return Dict{String,Any}("c" => b^2)
+	end
+)
+success, outputs = run(p;
+	touch_run_id_file = false
+) # outputs will be refreshed
+inputs, outputs = Pipelines.xxputs_completion_and_check(p, Dict{String, Any}(), Dict{String, Any}())

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,6 +12,7 @@ using Test
 @test Pipelines.parse_default_element("x" => Int => 5) == ("x", Int, 5)
 @test Pipelines.parse_default_element("x" => Int => DataType) == ("x", DataType, Int)
 @test Pipelines.parse_default_element("x" => DataType => Int) == ("x", DataType, Int)
+@test Pipelines.parse_default_element( :b => (5.0 => Int)) == ("b", Int, 5)
 
 @test_throws ErrorException Pipelines.parse_default_element("x" => Int => "5")
 @test_throws ErrorException Pipelines.parse_default_element("x" => "5" => Int)
@@ -19,6 +20,12 @@ using Test
 
 v = ["A", "B" => Int, "C" => 9.0 => Float64]
 @test Pipelines.parse_default(v) == (["A", "B", "C"], DataType[Any, Int64, Float64], Any[nothing, nothing, 9.0])
+
+v = ["A", :B => Int, "C" => 9.0 => Float64]
+@test Pipelines.parse_default(v) == (["A", "B", "C"], DataType[Any, Int64, Float64], Any[nothing, nothing, 9.0])
+
+v = ["A", :B => Int => 5.0, "C" => 9.0 => Float64]
+@test Pipelines.parse_default(v) == (["A", "B", "C"], DataType[Any, Int64, Float64], Any[nothing, 5, 9.0])
 
 ## keyword interpolation
 allputs = Dict(
@@ -99,7 +106,7 @@ run(p,
 p_nooutput = CmdProgram(
     cmd_dependencies = [julia],
     id_file = "id_file",
-    inputs = ["input", "input2"],
+    inputs = ["input", "input2", "optional_arg", "optional_arg2"],
     cmd = `echo input input2`
 )
 
@@ -113,7 +120,7 @@ run(p_nooutput,
 cmd, run_id_file = run(p,
     inputs = Dict(
         "input" => `in1`,
-        "input2" => `in2`
+        "input2" => 5.0
     ),
     outputs = Dict(
         "output" => `out`
@@ -195,20 +202,51 @@ p = JuliaProgram(
 		"a" => 10.6,
 		"b" =>  5 => Int
 	],
-	outputs = [
-		"c" => "<a>.<b>"
-	],
+	outputs = "c" => "<a>.<b>",
 	main = (inputs, outputs) -> begin
-		a = inputs["a"]
-		b = inputs["b"]
-		println("inputs are ", a, " and ", b)
-		println("You can also use info in outputs: ", outputs["c"])
-		println("The returned value will be assigned to a new outputs")
-
-		return Dict{String,Any}("c" => b^2)
+		return Dict{String,Any}("c" => inputs["b"]^2)
 	end
 )
 success, outputs = run(p;
 	touch_run_id_file = false
-) # outputs will be refreshed
+)
 inputs, outputs = Pipelines.xxputs_completion_and_check(p, Dict{String, Any}(), Dict{String, Any}())
+
+p = JuliaProgram(
+	id_file = "id_file",
+	inputs = [
+		"a" => 10.6 => Float64,
+		"b" =>  5 => Int
+	],
+	outputs = "c" => "<a>.<b>",
+	main = (inputs, outputs) -> begin
+		return Dict{String,Any}("c" => inputs["b"]^2)
+	end
+)
+success, outputs = run(p;
+	touch_run_id_file = false
+)
+success, outputs = run(p,
+	inputs = Dict(
+		"a" => 10.6,
+		"b" =>  2.0
+	),
+	touch_run_id_file = false
+)
+
+success, outputs = run(p,
+	inputs = :a => 8,
+	touch_run_id_file = false
+)
+
+p = JuliaProgram(
+	id_file = "id_file",
+	inputs = [
+		:a => 10.6 => Float64,
+		:b =>  5 => Int
+	],
+	outputs = "c" => "<a>.<b>",
+	main = (inputs, outputs) -> begin
+		return Dict{String,Any}("c" => inputs["b"]^2)
+	end
+)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,19 @@ include("../src/Pipelines.jl")
 using .Pipelines
 using Test
 
+### util
+@test parse_default_element("x") == ("x", Any, nothing)
+@test parse_default_element("x" => Int) == ("x", Int, nothing)
+@test parse_default_element("x" => 5) == ("x", Any, 5)
+@test parse_default_element("x" => 5 => Int) == ("x", Int, 5)
+@test parse_default_element("x" => Int => 5) == ("x", Int, 5)
+@test parse_default_element("x" => Int => DataType) == ("x", DataType, Int)
+@test parse_default_element("x" => DataType => Int) == ("x", DataType, Int)
+
+@test_throws ErrorException parse_default_element("x" => Int => "5")
+@test_throws ErrorException parse_default_element("x" => "5" => Int)
+@test_throws ErrorException parse_default_element(5)
+
 ### cmd dependency
 
 julia = CmdDependency(


### PR DESCRIPTION
v0.3 update to Issue #2

- Building Program: Support type assertion and default arguments of `inputs` and `outputs`, such as `"arg" => 5`, `"arg" => Int`, `"arg" => 5 => Int`, `"arg" => Int => 5`.

- `Program` and `run(::Program)` no longer require `inputs` and `outputs` to be `Vector` or `Dict`. They can be both `Vector` or `Dict`, or even an element of `Vector` or `Dict`, as long as they can be converted. Eg:

  ```julia
  p = CmdProgram(
      cmd_dependencies = [julia],
      id_file = "id_file",
      inputs = [
          "input",
          "input2" => Int,
          "optional_arg" => 5,
          "optional_arg2" => 0.5 => Number
      ],
      outputs = "output" => "<input>.output"
      ,
      cmd = `echo input input2 optional_arg optional_arg2 output`
  )

  inputs = Dict(
      "input" => `in1`,
      "input2" => 2
  )

  outputs = [
      "output" => "out"
  ]

  run(p, inputs, outputs,
      skip_when_done = false,
      verbose = true,
      touch_run_id_file = false
  )
  ```

- Pretty print of `Program`. Eg:

  ```julia
  julia> p
  CmdProgram:
    name             → Command Program
    id_file          → id_file
    info_before      → auto
    info_after       → auto
    cmd_dependencies → CmdDependency[`/usr/software/julia-1.4.2/bin/julia -Cnative -J/usr/software/julia-1.4.2/lib/julia/sys.so -O3 -g1`]
    inputs           → "input"         :: Any    (required)
                       "input2"        :: Int64  (required)
                       "optional_arg"  :: Any    (default: 5)
                       "optional_arg2" :: Number (default: 0.5)
    validate_inputs  → do_nothing
    prerequisites    → do_nothing
    cmd              → `echo input input2 optional_arg optional_arg2 output`
    infer_outputs    → do_nothing
    outputs          → "output" :: Any (default: <input>.output)
    validate_outputs → do_nothing
    wrap_up          → do_nothing
  ```

